### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md
+
+## Repository Overview
+
+This repo holds the "one-click deployment" automation for eSignet on public
+cloud. It is infrastructure-as-code (IaC), not an eSignet application
+service — there is no source code for eSignet itself here, only the
+scripts, Terraform, CDK, and Helm values used to stand up eSignet on a
+cloud provider.
+
+There are exactly two top-level modules, one per cloud provider, and they
+are independent of each other (different languages, different tools, no
+shared code):
+
+| Folder | Cloud | Guide |
+|--------|-------|-------|
+| [`aws/`](aws/AGENTS.md) | Amazon Web Services | [aws/AGENTS.md](aws/AGENTS.md) |
+| [`gcp/`](gcp/AGENTS.md) | Google Cloud Platform | [gcp/AGENTS.md](gcp/AGENTS.md) |
+
+Read the subfolder guide for the module you are changing — this root file
+only covers what is common to both.
+
+## Technology Stack
+
+- `aws/`: AWS CDK (TypeScript) for AWS resource provisioning, plus Helm
+  charts run from CDK for deploying eSignet services onto EKS.
+- `gcp/`: Terraform for GCP resource provisioning, Google Cloud Build YAML
+  pipelines that wrap `terraform plan`/`apply`, and Helm charts for
+  deploying eSignet services onto GKE.
+- No application source code (Java/Spring, etc.) lives in this repo.
+
+## Build & Test Commands
+
+There is no single build/test command for the whole repo — each module has
+its own tool. See `aws/AGENTS.md` for CDK commands (`cdk synth`, `cdk
+deploy`, `cdk destroy`, `npm test`) and `gcp/AGENTS.md` for Terraform /
+Cloud Build commands (`terraform plan`, `terraform apply`, `gcloud builds
+submit`).
+
+## Configuration
+
+Both modules read environment-specific values from a checked-in `.env`
+file (`aws/.env`, `gcp/.env`) rather than a `.env.example` template. Both
+files are already present in the repository with sample/demo values (an
+AWS account ID, RDS password, domain, and certificate ARN in `aws/.env`;
+Helm chart/image versions in `gcp/.env`). Never commit real account IDs,
+passwords, ARNs, or other environment-specific secrets when editing these
+files — replace the sample values locally and keep the diff you push
+limited to what the task actually requires.
+
+## Project Structure Notes
+
+```text
+.
+├── aws/   AWS CDK (TypeScript) + Helm — see aws/AGENTS.md
+└── gcp/   Terraform + Cloud Build + Helm — see gcp/AGENTS.md
+```
+
+There is no root README, no CI workflow directory (`.github/workflows`)
+in this repository, and no other `AGENTS.md`/`CLAUDE.md` files exist yet
+— this change adds the first ones.
+
+## Development Workflow
+
+1. Work inside the one module (`aws/` or `gcp/`) your change concerns;
+   avoid cross-editing both unless the change genuinely applies to both.
+2. Follow the module-specific guide for how to validate a change (CDK
+   synth, Terraform plan, etc.) before proposing it.
+3. Keep documentation (`README.md`, `documentation/*.md` under `aws/`)
+   in sync with any change to deployment steps, stack names, or Helm
+   chart versions.
+
+## Pull Request Guidelines
+
+- This repo has no CI workflows, so there is no automated check to lean
+  on — describe in the PR body what you validated manually (e.g. `cdk
+  synth` succeeded, `terraform plan` output reviewed).
+- Reference the tracking issue/ticket in the PR description.
+- Keep PRs scoped to one module (`aws/` or `gcp/`) where possible.
+
+## Repository-Specific Considerations
+
+- This is IaC for real cloud infrastructure. Changes here can provision
+  or, if run carelessly, destroy real AWS/GCP resources (databases, EKS/
+  GKE clusters, load balancers). Never run `cdk deploy`, `cdk destroy`,
+  `terraform apply`, `terraform destroy`, or the `gcloud builds submit
+  ... destroy-script.yaml` pipelines against a real account/project as
+  part of a routine code change — those are operator actions, not part
+  of writing or reviewing code.
+- Helm chart archives (`.tgz`) and `index.yaml` are vendored under
+  `aws/packages/`; don't hand-edit these, regenerate/re-fetch them
+  through the documented process instead.
+
+## Agent rules
+
+### Do
+
+1. Read the relevant module's `AGENTS.md` (`aws/AGENTS.md` or
+   `gcp/AGENTS.md`) before touching files in that folder.
+2. Verify claims about commands, versions, and file paths against the
+   actual files in the repo before writing documentation or comments.
+3. Treat `aws/.env` and `gcp/.env` as configuration templates that
+   already contain sample values — replace samples with your own
+   locally, and keep secrets out of anything you commit or push.
+4. Flag any command that can create, modify, or destroy cloud resources
+   (`cdk deploy`/`destroy`, `terraform apply`/`destroy`, Cloud Build
+   destroy pipelines) clearly when suggesting it.
+
+### Do not
+
+1. Do not run `cdk deploy`, `cdk destroy`, `terraform apply`, `terraform
+   destroy`, or a Cloud Build destroy pipeline against a real cloud
+   account/project without the user explicitly asking for that specific
+   action.
+2. Do not commit real AWS account IDs, database passwords, certificate
+   ARNs, GCP project IDs, or other secrets — even though sample values
+   already exist in `aws/.env`/`gcp/.env`, don't replace them with real
+   ones in a commit.
+3. Do not assume a CI pipeline will catch mistakes — this repo has no
+   `.github/workflows`.
+4. Do not hand-edit the vendored Helm chart archives under
+   `aws/packages/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,17 @@ file (`aws/.env`, `gcp/.env`) rather than a `.env.example` template.
 demo/sample values, including an AWS account ID, an `RDS_PASSWORD`, a
 domain, and a certificate ARN — treat any values already in that file as
 compromised (they are visible in a public repo) rather than as a safe
-pattern to copy. Do not add or replace values in `aws/.env`/`gcp/.env`
-with anything that could be a real secret; if a value must vary per
-deployment, prefer an untracked local override or a secrets manager over
-editing the tracked file. Never commit real account IDs, passwords, ARNs,
-or other environment-specific secrets when editing these files.
+pattern to copy. `aws/lib/config.ts` loads `aws/.env` from a fixed
+relative path via `dotenv.config(...)`, and `gcp/builds/apps/deploy-script.yaml`
+sources `gcp/.env` directly from the working directory — neither loader
+supports a separate override path or filename today, so whatever is
+committed at `aws/.env`/`gcp/.env` is what gets used. Do not add or
+replace values in either file with anything that could be a real secret.
+The durable fix — converting these to `.gitignore`d files with a
+`.env.example` template, so a real value never has to be tracked — is a
+repository change outside the scope of this documentation-only PR; until
+that lands, never commit real account IDs, passwords, ARNs, or other
+environment-specific secrets when editing these files.
 
 ## Project Structure Notes
 
@@ -104,7 +110,10 @@ in this repository, and no other `AGENTS.md`/`CLAUDE.md` files exist yet
    actual files in the repo before writing documentation or comments.
 3. Treat `aws/.env` and `gcp/.env` as configuration templates that
    already contain sample values — replace samples with your own
-   locally, and keep secrets out of anything you commit or push.
+   locally only as uncommitted, unstaged changes; keep secrets out of
+   anything you commit or push. Run `git status`/`git diff` on these
+   two files before staging anything in `aws/` or `gcp/` to confirm
+   you haven't picked up a real value.
 4. Flag any command that can create, modify, or destroy cloud resources
    (`cdk deploy`/`destroy`, `terraform apply`/`destroy`, Cloud Build
    destroy pipelines) clearly when suggesting it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,13 +40,16 @@ submit`).
 ## Configuration
 
 Both modules read environment-specific values from a checked-in `.env`
-file (`aws/.env`, `gcp/.env`) rather than a `.env.example` template. Both
-files are already present in the repository with sample/demo values (an
-AWS account ID, RDS password, domain, and certificate ARN in `aws/.env`;
-Helm chart/image versions in `gcp/.env`). Never commit real account IDs,
-passwords, ARNs, or other environment-specific secrets when editing these
-files — replace the sample values locally and keep the diff you push
-limited to what the task actually requires.
+file (`aws/.env`, `gcp/.env`) rather than a `.env.example` template.
+`aws/.env` is already tracked in this repository with what look like
+demo/sample values, including an AWS account ID, an `RDS_PASSWORD`, a
+domain, and a certificate ARN — treat any values already in that file as
+compromised (they are visible in a public repo) rather than as a safe
+pattern to copy. Do not add or replace values in `aws/.env`/`gcp/.env`
+with anything that could be a real secret; if a value must vary per
+deployment, prefer an untracked local override or a secrets manager over
+editing the tracked file. Never commit real account IDs, passwords, ARNs,
+or other environment-specific secrets when editing these files.
 
 ## Project Structure Notes
 
@@ -66,9 +69,9 @@ in this repository, and no other `AGENTS.md`/`CLAUDE.md` files exist yet
    avoid cross-editing both unless the change genuinely applies to both.
 2. Follow the module-specific guide for how to validate a change (CDK
    synth, Terraform plan, etc.) before proposing it.
-3. Keep documentation (`README.md`, `documentation/*.md` under `aws/`)
-   in sync with any change to deployment steps, stack names, or Helm
-   chart versions.
+3. Keep the relevant module documentation in sync with changes to
+   deployment steps, stack names, Terraform stages, or Helm chart
+   versions. This includes `aws/documentation/*.md` and `gcp/README.md`.
 
 ## Pull Request Guidelines
 

--- a/aws/AGENTS.md
+++ b/aws/AGENTS.md
@@ -1,0 +1,165 @@
+# AGENTS.md
+
+Scope: this file covers the `aws/` module only. See the [root
+AGENTS.md](../AGENTS.md) for the repo-wide overview.
+
+## Repository Overview
+
+`aws/` is an AWS CDK v2 (TypeScript) application, `esignet-aws-automation`,
+that provisions AWS infrastructure (VPC, RDS Aurora PostgreSQL, EKS on
+EC2, an Application Load Balancer) and then deploys eSignet and its
+dependent services (Keycloak, SoftHSM, Kafka, Artifactory, eSignet API,
+OIDC UI, etc.) into that EKS cluster via Helm charts invoked from CDK
+stacks.
+
+## Technology Stack
+
+- AWS CDK v2 (`aws-cdk-lib` 2.133.0), TypeScript (~5.3.3)
+- Jest + ts-jest for tests
+- Helm charts (vendored as `.tgz` under `aws/packages/`) deployed from
+  CDK Helm-chart constructs
+- `dotenv` to load `aws/.env` into `lib/config.ts`
+
+## Build & Test Commands
+
+Run these from inside `aws/`:
+
+```bash
+# Install dependencies
+npm install
+
+# Compile TypeScript
+npm run build
+
+# Run unit tests (Jest)
+npm test
+
+# Emit the synthesized CloudFormation templates (safe, no AWS calls)
+npx cdk synth
+
+# List the stacks CDK would deploy
+npx cdk list
+```
+
+`npm run watch` recompiles TypeScript on change; it does not deploy
+anything.
+
+### Deploying (provisions real AWS resources)
+
+These commands talk to a real AWS account and create or destroy billed
+resources. Only run them when the user explicitly asks to deploy/tear
+down infrastructure, and only after `aws/.env` has been filled in with
+real values for that account:
+
+```bash
+# One-time per account/region
+npx cdk bootstrap aws://ACCOUNT_ID/REGION
+
+# Deploy one named stack
+npx cdk deploy STACK_NAME
+
+# Deploy every stack, letting CDK resolve the dependency order
+npx cdk deploy --all
+
+# Tear down stacks created by this app
+npx cdk destroy STACKS
+```
+
+## Configuration
+
+All CDK input values are read from `aws/.env` (loaded by
+`aws/lib/config.ts` via `dotenv`) — this file is committed to the repo
+with sample/demo values already filled in (AWS account ID, RDS password,
+domain, ACM certificate ARN, EKS cluster name, load balancer names).
+Edit it in place with values for your own AWS account before running any
+`cdk` command; do not commit your real values back.
+
+Mandatory variables: `ACCOUNT`, `RDS_PASSWORD`, `CERTIFICATE_ARN`.
+Optional (have defaults in `lib/config.ts`): `REGION` (default
+`ap-south-1`), `CIDR`, `MAX_AZS` (default 2), `RDS_USER` (default
+`postgres`), `EKS_CLUSTER_NAME` (default `ekscluster-esignet-demo`),
+`DOMAIN`, `KEYCLOAK_LOADBALANCER_NAME`, `ESIGNET_LOADBALANCER_NAME`. Full
+descriptions are in
+[`documentation/01-Deployment-CDK-eSignet.md`](documentation/01-Deployment-CDK-eSignet.md).
+
+## Project Structure Notes
+
+```text
+aws/
+├── bin/esignet-aws-automation.ts   CDK app entrypoint
+├── lib/                            One file per CDK stack
+│   ├── config.ts                   Loads aws/.env into typed config
+│   ├── vpc-stack.ts, rds-stack.ts, eks-ec2-stack.ts,
+│   │   ec2-loadbalancer-stack.ts   AWS resource stacks
+│   └── *-helm-stack.ts             Stacks that install Helm charts
+│       (mosipcommon, esignetbootstrap, keycloak, keycloakinit,
+│       postgresinit, esignetinit, esignet, oidcui)
+├── test/                           Jest tests (esignet-aws-automation.test.ts)
+├── packages/                       Vendored Helm chart archives (.tgz) + index.yaml
+├── documentation/                  Step-by-step deployment guides
+├── helm/                           Helm chart sources used by the stacks
+├── kafka-cdk/                      Kafka-related CDK code
+├── cdk.json, cdk.context.json      CDK app/runtime configuration
+└── .env                            CDK input values (see Configuration)
+```
+
+Stack-to-file mapping and the Helm chart deployment order are documented
+in full in
+[`documentation/01-Deployment-CDK-eSignet.md`](documentation/01-Deployment-CDK-eSignet.md).
+Deploying the Helm charts directly (without CDK) is covered in
+[`documentation/02-Deployment-Helm-eSignet.md`](documentation/02-Deployment-Helm-eSignet.md),
+and post-install steps are in
+[`documentation/03-Post-Installation-Procedure.md`](documentation/03-Post-Installation-Procedure.md).
+
+## Development Workflow
+
+1. Change the relevant stack file under `lib/`.
+2. Run `npm run build` and `npx cdk synth` to confirm the stack still
+   synthesizes without errors.
+3. Run `npm test` for any affected unit tests.
+4. Update the matching table/section in
+   `documentation/01-Deployment-CDK-eSignet.md` if you add, rename, or
+   remove a stack, or change a mandatory/optional `.env` variable.
+5. Do not run `cdk deploy`/`cdk destroy` as part of routine code changes
+   — that provisions or destroys real AWS resources.
+
+## Pull Request Guidelines
+
+- State which stack(s) you changed and what `cdk synth`/`npm test`
+  output you checked.
+- If you changed `lib/config.ts` or added a new `.env` variable, update
+  the variable table in `documentation/01-Deployment-CDK-eSignet.md` in
+  the same PR.
+- No CI workflow runs these checks automatically in this repo — call out
+  what you validated manually in the PR description.
+
+## Repository-Specific Considerations
+
+- `aws/.env` already contains realistic-looking sample values (an AWS
+  account number, RDS password, domain, certificate ARN). Treat these as
+  placeholders to replace locally, not as real credentials to reuse or
+  commit.
+- `npm run watch` and `.gitignore` exclude compiled `*.js`/`*.d.ts`
+  output and `cdk.out/` — don't hand-commit build output.
+- Helm chart archives under `packages/` are vendored binaries; update
+  them through the project's normal chart-packaging process rather than
+  editing the `.tgz` files directly.
+
+## Agent rules
+
+### Do
+
+1. Run `npm run build`, `npx cdk synth`, and `npm test` to validate
+   changes to stacks or config.
+2. Keep `documentation/01-Deployment-CDK-eSignet.md` in sync with stack
+   and `.env` variable changes.
+3. Treat every value in `aws/.env` as a local override — edit it in
+   place for local runs, but do not push real secrets.
+
+### Do not
+
+1. Do not run `npx cdk deploy` or `npx cdk destroy` against a real AWS
+   account unless explicitly asked to deploy/tear down infrastructure.
+2. Do not commit a real AWS account ID, RDS password, or certificate ARN
+   into `aws/.env`.
+3. Do not hand-edit the `.tgz` Helm chart archives under `packages/`.

--- a/gcp/AGENTS.md
+++ b/gcp/AGENTS.md
@@ -1,0 +1,199 @@
+# AGENTS.md
+
+Scope: this file covers the `gcp/` module only. See the [root
+AGENTS.md](../AGENTS.md) for the repo-wide overview.
+
+## Repository Overview
+
+`gcp/` is the one-click deployment automation for eSignet on Google
+Cloud. It provisions infrastructure with Terraform, orchestrates that
+Terraform through Google Cloud Build YAML pipelines, and then deploys
+eSignet and its dependent services (SoftHSM, Artifactory, Keycloak,
+Postgres-init, eSignet, OIDC UI, Keycloak-init, optional mock identity
+system) onto GKE with Helm.
+
+Deployment is split into two stages: **pre-config** (Terraform, creates
+the landing-zone infra) and **apps** (deploys the Helm-based services).
+Each stage has its own Cloud Build pipeline under `builds/`.
+
+## Technology Stack
+
+- Terraform (pinned to `hashicorp/terraform:1.6.1` in the Cloud Build
+  steps) for GCP resource provisioning
+- Google Cloud Build (`builds/*/deploy-script.yaml`,
+  `builds/*/destroy-script.yaml`) as the wrapper that runs
+  `terraform init` / `plan` / `apply` (or `plan -destroy` / `apply` for
+  teardown)
+- Helm charts for deploying eSignet services onto GKE
+- `gcloud` / `kubectl` CLIs for setup and cluster access
+
+## Build & Test Commands (how to plan/apply)
+
+There is no unit-test suite here; validation is done by running
+Terraform/Cloud Build against a GCP project. Run from `gcp/` unless
+noted:
+
+```bash
+# One-time setup: auth, project config, enabling services, service account
+bash deployments/scripts/setup_gcp.sh
+
+# Terraform state bucket (once per project)
+PROJECT_ID="your-project-id"
+REGION="asia-south1"
+gcloud storage buckets create "gs://${PROJECT_ID}-esignet-state" \
+  --project="${PROJECT_ID}" --default-storage-class=STANDARD \
+  --location="${REGION}" --uniform-bucket-level-access
+```
+
+### Provisioning infrastructure (Terraform via Cloud Build — provisions real resources)
+
+```bash
+PROJECT_ID="your-project-id"
+SERVICE_ACCOUNT="your-project-id-sa@your-project-id.iam.gserviceaccount.com"
+
+gcloud builds submit --config="./builds/infra/deploy-script.yaml" \
+  --project="${PROJECT_ID}" \
+  --substitutions=_PROJECT_ID_="${PROJECT_ID}",_SERVICE_ACCOUNT_="${SERVICE_ACCOUNT}",_LOG_BUCKET_="${PROJECT_ID}-esignet-state"
+```
+
+The pipeline runs, in order, `terraform init`, `terraform plan -out
+out.plan -var-file=terraform-variables/dev/pre-config/pre-config.tfvars
+...`, then `terraform apply out.plan` inside
+`terraform-scripts/pre-config/`.
+
+### Destroying infrastructure (destructive — real resources, real data loss)
+
+```bash
+gcloud builds submit --config="./builds/infra/destroy-script.yaml" \
+  --project="${PROJECT_ID}" \
+  --substitutions=_PROJECT_ID_="${PROJECT_ID}",_SERVICE_ACCOUNT_="${SERVICE_ACCOUNT}",_LOG_BUCKET_="${PROJECT_ID}-esignet-state"
+```
+
+This runs `terraform plan -destroy` then `terraform apply` on that
+destroy plan — it deletes the infrastructure the deploy pipeline
+created. Never run this against a real project as part of a routine
+change.
+
+### Deploying / destroying services (Helm, via Cloud Build)
+
+```bash
+REGION="asia-south1"
+EMAIL_ID="you@example.com"
+DOMAIN_NAME="your.domain.example"
+ENABLE_MOCK=false
+
+gcloud builds submit --config="./builds/apps/deploy-script.yaml" \
+  --region="${REGION}" --project="${PROJECT_ID}" \
+  --substitutions=_PROJECT_ID_="${PROJECT_ID}",_REGION_="${REGION}",_LOG_BUCKET_="${PROJECT_ID}-esignet-state",_EMAIL_ID_="${EMAIL_ID}",_DOMAIN_="${DOMAIN_NAME}",_SERVICE_ACCOUNT_="${SERVICE_ACCOUNT}",_ENABLE_MOCK_="${ENABLE_MOCK}"
+```
+
+`builds/apps/destroy-script.yaml` tears the services back down with the
+matching substitutions — same caution as above applies.
+
+## Configuration
+
+`gcp/.env` holds the Helm chart versions and Docker image/versions for
+each service (softhsm, artifactory, keycloak, postgres-init, esignet,
+oidc-ui, keycloak-init, mock-identity-system); update it to change which
+chart/image versions get deployed.
+
+`terraform-variables/dev/pre-config/pre-config.tfvars` holds the actual
+Terraform variable values for the `pre-config` stage (matched against
+`terraform-scripts/pre-config/variables.tf`). Cloud Build substitution
+variables (`_PROJECT_ID_`, `_SERVICE_ACCOUNT_`, `_LOG_BUCKET_`, `_REGION_`,
+`_EMAIL_ID_`, `_DOMAIN_`, `_ENABLE_MOCK_`) are passed on the command line
+via `--substitutions`, not stored in a file — do not hardcode real
+project IDs or service account emails into the YAML pipeline files.
+
+`.terraform/` and `**/*.plan` are gitignored at the repo root — Terraform
+local state/plan artifacts should never be committed.
+
+## Project Structure Notes
+
+```text
+gcp/
+├── .env                        Helm chart/image versions
+├── assets/                     Architecture diagrams
+├── builds/
+│   ├── infra/                  Cloud Build pipelines for Terraform pre-config (deploy/destroy)
+│   └── apps/                   Cloud Build pipelines for Helm app deployment (deploy/destroy)
+├── db_scripts/                 Database setup scripts
+├── deployments/
+│   ├── configs/                Config files used during deployment
+│   └── scripts/setup_gcp.sh    GCP auth/project/service-account bootstrap script
+├── postman_collections/        Postman collection + environment for the OIDC demo flow
+├── terraform-scripts/
+│   └── pre-config/              backend.tf, pre-config.tf, variables.tf
+└── terraform-variables/
+    └── dev/pre-config/pre-config.tfvars   Actual values for variables.tf
+```
+
+Only the `dev` / `pre-config` Terraform stage exists today — there is no
+`setup`/main-infra Terraform stage checked in yet, even though the
+README describes deployment as split into "Pre-Config" and "Setup"
+stages; the "apps" side of that second stage is instead handled by the
+Helm-based `builds/apps/*.yaml` pipelines.
+
+## Development Workflow
+
+1. Change Terraform under `terraform-scripts/pre-config/` and the
+   matching values in `terraform-variables/dev/pre-config/pre-config.tfvars`
+   together.
+2. Validate locally with `terraform fmt` / `terraform validate` /
+   `terraform plan` against a sandbox project before proposing a change
+   — do not `apply` as part of routine review.
+3. If you change a Helm chart or image version, update `gcp/.env` and
+   the version table in `gcp/README.md` together.
+4. Keep `README.md` in sync with any change to the deployment steps or
+   folder layout.
+
+## Pull Request Guidelines
+
+- State which stage (`infra`/Terraform vs `apps`/Helm) your change
+  touches, and what you validated (e.g. `terraform validate`, `terraform
+  plan` output reviewed against a sandbox project).
+- No CI workflow exists in this repo to run these checks automatically —
+  call out manual validation in the PR description.
+- Do not include real project IDs, service account emails, or `.tfvars`
+  values from a real environment in PR descriptions or screenshots.
+
+## Repository-Specific Considerations
+
+- Everything under `builds/` and `terraform-scripts/` can provision or
+  destroy real GCP infrastructure (GKE cluster, Cloud SQL, networking).
+  Treat any `deploy-script.yaml` / `destroy-script.yaml` invocation, and
+  any direct `terraform apply`/`terraform destroy`, as an operator
+  action requiring explicit user confirmation — never run it as a side
+  effect of a code change.
+- The destroy pipelines run `terraform plan -destroy` then `apply` on
+  that plan, i.e. they permanently remove the resources the deploy
+  pipeline created (including the database) — flag this clearly before
+  suggesting it.
+- Secrets at runtime (DB password, Keycloak admin password, OIDC client
+  secret) are fetched from GCP Secret Manager / Kubernetes secrets via
+  `gcloud secrets versions access` and `kubectl get secret`, not stored
+  in this repo — see the "Steps to access..." sections of
+  [`README.md`](README.md).
+
+## Agent rules
+
+### Do
+
+1. Validate Terraform changes with `terraform fmt`/`validate`/`plan`
+   against a sandbox project, not the org's real project.
+2. Keep `gcp/.env`, `gcp/README.md`, and
+   `terraform-variables/dev/pre-config/pre-config.tfvars` consistent
+   with each other when changing chart versions or Terraform variables.
+3. Pass GCP identifiers (`_PROJECT_ID_`, `_SERVICE_ACCOUNT_`, etc.) as
+   Cloud Build `--substitutions` on the command line, matching the
+   existing pattern, instead of hardcoding them into YAML.
+
+### Do not
+
+1. Do not run `gcloud builds submit ... destroy-script.yaml` or
+   `terraform destroy` against a real GCP project unless explicitly
+   asked to tear down infrastructure.
+2. Do not run the `deploy-script.yaml` pipelines or `terraform apply`
+   against a real project as part of routine code review or refactors.
+3. Do not commit `.terraform/` directories, `*.plan` files, or real
+   project IDs/service account emails into tracked files.


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root AGENTS.md hub plus module-specific guides for the `aws/` (CDK + Helm) and `gcp/` (Terraform + Cloud Build + Helm) deployment modules, covering repository overview, tech stack, build/plan/apply commands, configuration, structure notes, and PR guidelines for AI agents and contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide guidance covering infrastructure architecture, development workflows, configuration, testing, deployment safety, and contribution practices.
  * Added AWS-specific documentation for CDK workflows, environment configuration, and deployment safeguards.
  * Added GCP-specific documentation for Terraform, Cloud Build, Helm deployments, secret handling, and infrastructure practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->